### PR TITLE
fix: Install pip and pip-tools in upgrade script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,10 @@ upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
 upgrade: $(COMMON_CONSTRAINTS_TXT)  ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
 	pip install -r requirements/pip.txt
 	pip install -q -r requirements/pip_tools.txt
-	pip-compile --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
+	pip-compile --upgrade --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
 	pip-compile --upgrade -o requirements/pip_tools.txt requirements/pip_tools.in
+	pip install -qr requirements/pip.txt
+	pip install -qr requirements/pip_tools.txt
 	pip-compile --upgrade -o requirements/base.txt requirements/base.in
 	pip-compile --upgrade -o requirements/test.txt requirements/test.in
 	pip-compile --upgrade -o requirements/ci.txt requirements/ci.in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,22 +6,16 @@
 #
 appdirs==1.4.4
     # via fs
-bleach==4.1.0
+bleach==5.0.0
     # via -r requirements/base.in
 boto==2.49.0
     # via -r requirements/base.in
-fs==2.4.14
+fs==2.4.16
     # via -r requirements/base.in
-mako==1.1.6
+mako==1.2.0
     # via -r requirements/base.in
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via mako
-packaging==21.3
-    # via bleach
-pyparsing==3.0.6
-    # via packaging
-pytz==2021.3
-    # via fs
 simplejson==3.17.6
     # via -r requirements/base.in
 six==1.16.0

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -8,32 +8,20 @@ appdirs==1.4.4
     # via
     #   -r requirements/test.txt
     #   fs
-bleach==4.1.0
+bleach==5.0.0
     # via -r requirements/test.txt
 boto==2.49.0
     # via -r requirements/test.txt
-fs==2.4.14
+fs==2.4.16
     # via -r requirements/test.txt
-mako==1.1.6
+mako==1.2.0
     # via -r requirements/test.txt
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via
     #   -r requirements/test.txt
     #   mako
-packaging==21.3
-    # via
-    #   -r requirements/test.txt
-    #   bleach
 pycodestyle==2.8.0
     # via -r requirements/test.txt
-pyparsing==3.0.6
-    # via
-    #   -r requirements/test.txt
-    #   packaging
-pytz==2021.3
-    # via
-    #   -r requirements/test.txt
-    #   fs
 simplejson==3.17.6
     # via -r requirements/test.txt
 six==1.16.0

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -13,8 +13,13 @@
 
 
 # using LTS django version
-Django<3.3
+Django<4.0
 
 # elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
 # elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
 elasticsearch<7.14.0
+
+setuptools<60
+
+# django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
+django-simple-history==3.0.0

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -1,3 +1,4 @@
+-c constraints.txt
 # Core dependencies for installing other packages
 
 pip

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,13 @@
 #
 #    make upgrade
 #
-wheel==0.36.2
+wheel==0.37.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==20.3.4
+pip==22.1.2
     # via -r requirements/pip.in
-setuptools==50.3.2
-    # via -r requirements/pip.in
+setuptools==59.8.0
+    # via
+    #   -c requirements/common_constraints.txt
+    #   -r requirements/pip.in

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -4,15 +4,15 @@
 #
 #    make upgrade
 #
-click==8.0.3
+click==8.1.3
     # via pip-tools
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.4.0
+pip-tools==6.6.2
     # via -r requirements/pip_tools.in
-tomli==2.0.0
+tomli==2.0.1
     # via pep517
-wheel==0.37.0
+wheel==0.37.1
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,32 +8,20 @@ appdirs==1.4.4
     # via
     #   -r requirements/base.txt
     #   fs
-bleach==4.1.0
+bleach==5.0.0
     # via -r requirements/base.txt
 boto==2.49.0
     # via -r requirements/base.txt
-fs==2.4.14
+fs==2.4.16
     # via -r requirements/base.txt
-mako==1.1.6
+mako==1.2.0
     # via -r requirements/base.txt
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via
     #   -r requirements/base.txt
     #   mako
-packaging==21.3
-    # via
-    #   -r requirements/base.txt
-    #   bleach
 pycodestyle==2.8.0
     # via -r requirements/test.in
-pyparsing==3.0.6
-    # via
-    #   -r requirements/base.txt
-    #   packaging
-pytz==2021.3
-    # via
-    #   -r requirements/base.txt
-    #   fs
 simplejson==3.17.6
     # via -r requirements/base.txt
 six==1.16.0


### PR DESCRIPTION
Updated the upgrade target script to check the compatibility of upgraded pip and pip-tools versions.
For reference, look at this https://github.com/openedx/edx-repo-health/pull/271 for new check added in edx-repo-health.

JIRA: https://2u-internal.atlassian.net/browse/BOM-3458