### PR TITLE
fix: django.po contains duplicate entries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 WORKING_DIR := recommender
 EXTRACT_DIR := $(WORKING_DIR)/conf/locale/en/LC_MESSAGES
-EXTRACTED_DJANGO := $(EXTRACT_DIR)/django-partial.po
-EXTRACTED_DJANGOJS := $(EXTRACT_DIR)/djangojs-partial.po
-EXTRACTED_TEXT := $(EXTRACT_DIR)/django.po
+EXTRACTED_DJANGO_PARTIAL := $(EXTRACT_DIR)/django-partial.po
+EXTRACTED_DJANGOJS_PARTIAL := $(EXTRACT_DIR)/djangojs-partial.po
+EXTRACTED_DJANGO := $(EXTRACT_DIR)/django.po
 
 COMMON_CONSTRAINTS_TXT=requirements/common_constraints.txt
 .PHONY: $(COMMON_CONSTRAINTS_TXT)
@@ -23,8 +23,11 @@ upgrade: $(COMMON_CONSTRAINTS_TXT)  ## update the requirements/*.txt files with 
 
 extract_translations: ## extract strings to be translated, outputting .po files
 	cd $(WORKING_DIR) && i18n_tool extract
-	mv $(EXTRACTED_DJANGO) $(EXTRACTED_TEXT)
-	tail -n +20 $(EXTRACTED_DJANGOJS) >> $(EXTRACTED_TEXT)
-	rm $(EXTRACTED_DJANGOJS)
-	sed -i'' -e 's/nplurals=INTEGER/nplurals=2/' $(EXTRACTED_TEXT)
-	sed -i'' -e 's/plural=EXPRESSION/plural=\(n != 1\)/' $(EXTRACTED_TEXT)
+	mv $(EXTRACTED_DJANGO_PARTIAL) $(EXTRACTED_DJANGO)
+	# Safely concatenate djangojs if it exists
+	if test -f $(EXTRACTED_DJANGOJS_PARTIAL); then \
+	  msgcat $(EXTRACTED_DJANGO) $(EXTRACTED_DJANGOJS_PARTIAL) -o $(EXTRACTED_DJANGO) && \
+	  rm $(EXTRACTED_DJANGOJS_PARTIAL); \
+	fi
+	sed -i'' -e 's/nplurals=INTEGER/nplurals=2/' $(EXTRACTED_DJANGO)
+	sed -i'' -e 's/plural=EXPRESSION/plural=\(n != 1\)/' $(EXTRACTED_DJANGO)


### PR DESCRIPTION
fix: `django.po` contains duplicate entries

This is considered a patch for https://github.com/openedx/RecommenderXBlock/pull/68 . Transefix failed to add translation extracted from this repo because of a duplicate msg in `django.po`

References
----------

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Check the links above for full information about the overall project.

Internalization is being rearchitected in Open edX Python, XBlock, Micro-frontend, and other projects. There are a number of immediately visible changes:
 - Remove source and language translations from the repositories, hence no `.json`, `.po` or `.mo` files will be committed into the repos.
 - Add standardized `make extract_translations` in all repositories
 - Push user-facing messages strings into [openedx/openedx-translations](https://github.com/openedx/openedx-translations/).
 - Integrate root repositories with [openedx/openedx-atlas](https://github.com/openedx/openedx-atlas/) to pull translations on build/deploy time

Breaking Changes
----------------

One of the primary goals of the project is to **avoid breaking changes**. If you noticed any suspicious code, please raise your concern. But before that, please know the strategy we're following to avoid breaking changes

**For XBlocks:**
 - The standard translation path must be `conf/locale`. Therefore, we are creating a link from `conf/locale` to `translations` so Atlas can find the path without disrupting the current way of having translations locally within the XBlocks
 - [openedx-translations](https://github.com/openedx/openedx-translations) will have a related PR that adds the XBlock to the pipeline. This will not affect the current way of managing/updating translations
 - At the end of the project, a clear change log will be added and all translations will be handled by Atlas. Thus, the local translation will be removed from the repo within the version bump
 - A notification for the community will be published to ensure that everyone knows why translations directories are removed from all repos