### PR TITLE
fix: handle exceptions without a message attribute on compile translations e.g. FileNotFoundError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ class XBlockInstall(_install):
                         self.announce('Compiling translation at %s' % po_path)
                         subprocess.check_call(['msgfmt', po_path, '-o', mo_path], cwd=self.install_lib)
         except Exception as ex:
-            self.announce('Translations compilation failed: %s' % ex.message)
+            self.announce('Translations compilation failed: %s' % getattr(ex, 'message', str(ex)))
 
 
 def package_data(pkg, root_list):


### PR DESCRIPTION
## Description

Avoids causing another exception in the exception handling of compile_translations() in installation.

## Testing instructions

1. Install in an environment where compiling translations will fail with FileNotFoundError (e.g. if msgfmt is not installed)
2. See that installation succeeds

## Other information

Private-ref: https://tasks.opencraft.com/browse/BB-8077