### PR TITLE
feat: valid S3 expiration time

### DIFF
--- a/recommender/__init__.py
+++ b/recommender/__init__.py
@@ -6,4 +6,4 @@ students solving a given problem.
 # which is not loaded when running `manage.py` commands (which is used by `make compile_translations`)
 # from .recommender import RecommenderXBlock
 
-__version__ = '2.1.0'
+__version__ = '2.1.1'

--- a/recommender/recommender.py
+++ b/recommender/recommender.py
@@ -285,7 +285,10 @@ class RecommenderXBlock(HelperXBlock):
         We benchmarked this as less than 8ms on a sandbox machine.
         """
         if filename.startswith('fs://'):
-            return str(self.fs.get_url(filename.replace('fs://', ''), 1000 * 60 * 60 * 10))
+            # 604800 seconds is the maximum allowed expiration by S3.
+            # If this is instead filesystem-backed, the timeout argument has
+            # no effect.
+            return str(self.fs.get_url(filename.replace('fs://', ''), 604800))
         else:
             return filename
 


### PR DESCRIPTION
## Description

Recommender XBlock will currently generate invalid URLs if used with S3 backend. This fixes that.

Using the filesystem backend should be unaffected as it ignores the timeout parameter (https://github.com/openedx/django-pyfs/blob/v3.4.1/djpyfs/djpyfs.py#L116).

## Testing instructions

1. Configure openedx-django-pyfs to use S3
      ```python
      DJFS = {
          'type': 's3fs',
          'bucket': AWS_STORAGE_BUCKET_NAME,
          'prefix': 'pyfs/',
          # Note that explicitly passing credentials requires openedx-django-pyfs >= 3.4.1
          'aws_access_key_id': AWS_ACCESS_KEY_ID,
          'aws_secret_access_key': AWS_SECRET_ACCESS_KEY
      }
      ```
2. Add a resource in the XBlock, include a screenshot
3. See that the screenshot is displayed
4. Configure openedx-django-pyfs to use the local filesystem
      ```python
      DJFS = {
          'type': 'osfs',
          'directory_root': '/tmp/pyfs',
          'url_root': '/static/djpyfs'
      }
      ```
5. Add a resource in the XBlock, include a screenshot
6. See that the screenshot is displayed

## Other information

Private-ref: https://tasks.opencraft.com/browse/BB-8077