### PR TITLE
fix: fix pypi publish workflow build

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: 3.8
 
       - name: Install get-text
-        run: apt-get install gettext
+        run: sudo apt-get install gettext
 
       - name: Install pip
         run: pip install -r requirements/pip.txt

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: 3.8
 
       - name: Install get-text
-        run: apt update && apt install gettext
+        run: apt-get install gettext
 
       - name: Install pip
         run: pip install -r requirements/pip.txt

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,6 +1,7 @@
 name: Publish package to PyPI
 
 on:
+  pull_request:
   push:
     tags:
       - '*'
@@ -16,6 +17,9 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
+
+      - name: Install get-text
+        run: apt update && apt install gettext
 
       - name: Install pip
         run: pip install -r requirements/pip.txt

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,7 +1,6 @@
 name: Publish package to PyPI
 
 on:
-  pull_request:
   push:
     tags:
       - '*'

--- a/recommender/__init__.py
+++ b/recommender/__init__.py
@@ -6,4 +6,4 @@ students solving a given problem.
 # which is not loaded when running `manage.py` commands (which is used by `make compile_translations`)
 # from .recommender import RecommenderXBlock
 
-__version__ = '2.1.1'
+__version__ = '2.1.2'


### PR DESCRIPTION
## Description
- Fix the pypi publish workflow so the package can be upgraded on PyPI.
- Bumped the package version since `2.1.1` was used to test the changes.

## Testing
- Tested the workflow build by triggering custom build against the pull request. 
- Successfully released version [2.1.1](https://pypi.org/project/recommender-xblock/2.1.1/) on PyPI.