### PR TITLE
feat: add i18n_js_namespace to support atlas - FC-0012

### DIFF
--- a/recommender/utils.py
+++ b/recommender/utils.py
@@ -1,0 +1,24 @@
+"""Utils for the Recommender XBlock"""
+
+
+def _(text):
+    """
+    Make '_' a no-op so we can scrape strings
+    """
+    return text
+
+
+def ngettext_fallback(text_singular, text_plural, number):
+    """ Dummy `ngettext` replacement to make string extraction tools scrape strings marked for translation """
+    if number == 1:
+        return text_singular
+    else:
+        return text_plural
+
+
+class DummyTranslationService:
+    """
+    Dummy drop-in replacement for i18n XBlock service
+    """
+    gettext = _
+    ngettext = ngettext_fallback

--- a/translation_settings.py
+++ b/translation_settings.py
@@ -11,7 +11,7 @@ https://docs.djangoproject.com/en/1.11/ref/settings/
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 from __future__ import absolute_import
 import os
-BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+BASE_DIR = os.path.dirname(__file__)
 
 
 # Quick-start development settings - unsuitable for production
@@ -81,7 +81,7 @@ LANGUAGES = [
     ('zh_CN', 'Chinese (China)'),
 ]
 
-LOCALE_PATHS = [os.path.join(BASE_DIR, "locale")]
+LOCALE_PATHS = [os.path.join(BASE_DIR, "recommender", "conf", "locale")]
 
 STATICI18N_DOMAIN = 'text'
 STATICI18N_NAMESPACE = 'RecommenderXBlockI18N'


### PR DESCRIPTION
Implement OEP-58 JavaScript translations
---

Details:
* Proposal: https://github.com/openedx/edx-platform/pull/33166
* Supporting platform pull request: https://github.com/openedx/edx-platform/pull/33698
* Similar pull request: https://github.com/openedx/xblock-drag-and-drop-v2/pull/365

Testing
---

Local tutor 17.0.2
- [x] translations are still working including JS translations
![Screenshot from 2024-02-28 11-15-04](https://github.com/openedx/RecommenderXBlock/assets/17448993/7fc3f8a8-4690-46e6-8d0d-cfc2f94dc029)


References
---

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which implements the [Translation Infrastructure update OEP-58](https://docs.openedx.org/en/latest/developers/concepts/oep58.html).