### PR TITLE
chore: upgrade to django 5.2

### DIFF
--- a/recommender/__init__.py
+++ b/recommender/__init__.py
@@ -6,4 +6,4 @@ students solving a given problem.
 # which is not loaded when running `manage.py` commands (which is used by `make compile_translations`)
 # from .recommender import RecommenderXBlock
 
-__version__ = '3.1.0'
+__version__ = '4.0.0'

--- a/setup.py
+++ b/setup.py
@@ -94,5 +94,8 @@ setup(
         "Programming Language :: Python :: 3",
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Framework :: Django',
+        'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.2',
     ],
 )

--- a/translation_settings.py
+++ b/translation_settings.py
@@ -47,8 +47,6 @@ TIME_ZONE = 'UTC'
 
 USE_I18N = True
 
-USE_L10N = True
-
 USE_TZ = True
 
 


### PR DESCRIPTION
Fixes: https://github.com/openedx/RecommenderXBlock/issues/109

**Add Django 5.2 Support**

This PR updates the codebase to be compatible with Django 5.2 while maintaining compatibility with Django 4.2.

Changes Made:
* Ran django-upgrade to apply necessary syntax updates for Django 5.2
* Ensured all modifications remain backward-compatible with Django 4.2.

**Concerns:**

This repo doesn't use any django features and hence has no tests/tox for django.