### PR TITLE
chore: drop Python 3.11 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os:
         - ubuntu-latest
-        python-version: ['3.11', '3.12']
+        python-version: ['3.12']
     steps:
     - uses: actions/checkout@v6
     - name: setup python

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.11
+          python-version: 3.12
 
       - name: Install pip
         run: pip install -r requirements/pip.txt

--- a/recommender/__init__.py
+++ b/recommender/__init__.py
@@ -6,4 +6,4 @@ students solving a given problem.
 # which is not loaded when running `manage.py` commands (which is used by `make compile_translations`)
 # from .recommender import RecommenderXBlock
 
-__version__ = '4.0.1'
+__version__ = '5.0.0'

--- a/recommender/__init__.py
+++ b/recommender/__init__.py
@@ -6,4 +6,4 @@ students solving a given problem.
 # which is not loaded when running `manage.py` commands (which is used by `make compile_translations`)
 # from .recommender import RecommenderXBlock
 
-__version__ = '4.0.0'
+__version__ = '4.0.1'

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,42 +6,42 @@
 #
 appdirs==1.4.4
     # via fs
-asgiref==3.8.1
+asgiref==3.11.1
     # via django
-bleach==6.2.0
-    # via -r base.in
-django==4.2.28
+bleach==6.3.0
+    # via -r requirements/base.in
+django==5.2.12
     # via
-    #   -c common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   edx-i18n-tools
-edx-i18n-tools==1.7.0
-    # via -r base.in
+edx-i18n-tools==1.9.0
+    # via -r requirements/base.in
 fs==2.4.16
-    # via -r base.in
-lxml[html-clean,html_clean]==5.3.2
+    # via -r requirements/base.in
+lxml[html-clean]==6.0.2
     # via
     #   edx-i18n-tools
     #   lxml-html-clean
-lxml-html-clean==0.4.2
+lxml-html-clean==0.4.4
     # via lxml
 path==16.16.0
     # via edx-i18n-tools
 polib==1.2.0
     # via edx-i18n-tools
-pyyaml==6.0.2
+pyyaml==6.0.3
     # via edx-i18n-tools
-simplejson==3.20.1
-    # via -r base.in
+simplejson==3.20.2
+    # via -r requirements/base.in
 six==1.17.0
     # via fs
-sqlparse==0.5.4
+sqlparse==0.5.5
     # via django
-web-fragments==3.0.0
-    # via -r base.in
+web-fragments==3.1.0
+    # via -r requirements/base.in
 webencodings==0.5.1
     # via bleach
 webob==1.8.9
-    # via -r base.in
+    # via -r requirements/base.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -6,64 +6,64 @@
 #
 appdirs==1.4.4
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   fs
-asgiref==3.8.1
+asgiref==3.11.1
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   django
-bleach==6.2.0
-    # via -r test.txt
-django==4.2.28
+bleach==6.3.0
+    # via -r requirements/test.txt
+django==5.2.12
     # via
-    #   -c common_constraints.txt
-    #   -r test.txt
+    #   -c requirements/common_constraints.txt
+    #   -r requirements/test.txt
     #   edx-i18n-tools
-edx-i18n-tools==1.7.0
-    # via -r test.txt
+edx-i18n-tools==1.9.0
+    # via -r requirements/test.txt
 fs==2.4.16
-    # via -r test.txt
-lxml[html-clean]==5.3.2
+    # via -r requirements/test.txt
+lxml[html-clean]==6.0.2
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   edx-i18n-tools
     #   lxml-html-clean
-lxml-html-clean==0.4.2
+lxml-html-clean==0.4.4
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   lxml
 path==16.16.0
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   edx-i18n-tools
 polib==1.2.0
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   edx-i18n-tools
-pycodestyle==2.13.0
-    # via -r test.txt
-pyyaml==6.0.2
+pycodestyle==2.14.0
+    # via -r requirements/test.txt
+pyyaml==6.0.3
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   edx-i18n-tools
-simplejson==3.20.1
-    # via -r test.txt
+simplejson==3.20.2
+    # via -r requirements/test.txt
 six==1.17.0
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   fs
-sqlparse==0.5.4
+sqlparse==0.5.5
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   django
-web-fragments==3.0.0
-    # via -r test.txt
+web-fragments==3.1.0
+    # via -r requirements/test.txt
 webencodings==0.5.1
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   bleach
 webob==1.8.9
-    # via -r test.txt
+    # via -r requirements/test.txt
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -12,20 +12,9 @@
 #  this file from Github directly. It does not require packaging in edx-lint.
 
 # using LTS django version
-Django<5.0
+Django<6.0
 
 # elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
 # elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
 # See https://github.com/openedx/edx-platform/issues/35126 for more info
 elasticsearch<7.14.0
-
-# django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
-django-simple-history==3.0.0
-
-# Cause: https://github.com/openedx/edx-lint/issues/458
-# This can be unpinned once https://github.com/openedx/edx-lint/issues/459 has been resolved.
-pip<24.3
-
-# Cause: https://github.com/openedx/edx-lint/issues/475
-# This can be unpinned once https://github.com/openedx/edx-lint/issues/476 has been resolved.
-urllib3<2.3.0

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -6,13 +6,11 @@
 #
 packaging==26.0
     # via wheel
-wheel==0.46.2
-    # via -r pip.in
+wheel==0.46.3
+    # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==24.2
-    # via
-    #   -c common_constraints.txt
-    #   -r pip.in
-setuptools==78.1.1
-    # via -r pip.in
+pip==26.0.1
+    # via -r requirements/pip.in
+setuptools==82.0.0
+    # via -r requirements/pip.in

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -4,21 +4,21 @@
 #
 #    make upgrade
 #
-build==1.2.2.post1
+build==1.4.0
     # via pip-tools
-click==8.1.8
+click==8.3.1
     # via pip-tools
-packaging==24.2
+packaging==26.0
     # via
     #   build
     #   wheel
-pip-tools==7.4.1
-    # via -r pip_tools.in
+pip-tools==7.5.3
+    # via -r requirements/pip_tools.in
 pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-wheel==0.46.2
+wheel==0.46.3
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,64 +6,64 @@
 #
 appdirs==1.4.4
     # via
-    #   -r base.txt
+    #   -r requirements/base.txt
     #   fs
-asgiref==3.8.1
+asgiref==3.11.1
     # via
-    #   -r base.txt
+    #   -r requirements/base.txt
     #   django
-bleach==6.2.0
-    # via -r base.txt
-django==4.2.28
+bleach==6.3.0
+    # via -r requirements/base.txt
+django==5.2.12
     # via
-    #   -c common_constraints.txt
-    #   -r base.txt
+    #   -c requirements/common_constraints.txt
+    #   -r requirements/base.txt
     #   edx-i18n-tools
-edx-i18n-tools==1.7.0
-    # via -r base.txt
+edx-i18n-tools==1.9.0
+    # via -r requirements/base.txt
 fs==2.4.16
-    # via -r base.txt
-lxml[html-clean]==5.3.2
+    # via -r requirements/base.txt
+lxml[html-clean]==6.0.2
     # via
-    #   -r base.txt
+    #   -r requirements/base.txt
     #   edx-i18n-tools
     #   lxml-html-clean
-lxml-html-clean==0.4.2
+lxml-html-clean==0.4.4
     # via
-    #   -r base.txt
+    #   -r requirements/base.txt
     #   lxml
 path==16.16.0
     # via
-    #   -r base.txt
+    #   -r requirements/base.txt
     #   edx-i18n-tools
 polib==1.2.0
     # via
-    #   -r base.txt
+    #   -r requirements/base.txt
     #   edx-i18n-tools
-pycodestyle==2.13.0
-    # via -r test.in
-pyyaml==6.0.2
+pycodestyle==2.14.0
+    # via -r requirements/test.in
+pyyaml==6.0.3
     # via
-    #   -r base.txt
+    #   -r requirements/base.txt
     #   edx-i18n-tools
-simplejson==3.20.1
-    # via -r base.txt
+simplejson==3.20.2
+    # via -r requirements/base.txt
 six==1.17.0
     # via
-    #   -r base.txt
+    #   -r requirements/base.txt
     #   fs
-sqlparse==0.5.4
+sqlparse==0.5.5
     # via
-    #   -r base.txt
+    #   -r requirements/base.txt
     #   django
-web-fragments==3.0.0
-    # via -r base.txt
+web-fragments==3.1.0
+    # via -r requirements/base.txt
 webencodings==0.5.1
     # via
-    #   -r base.txt
+    #   -r requirements/base.txt
     #   bleach
 webob==1.8.9
-    # via -r base.txt
+    # via -r requirements/base.txt
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,6 @@ setup(
         "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Framework :: Django',
         'Framework :: Django :: 4.2',


### PR DESCRIPTION
## Summary

- Remove Python 3.11 from CI matrix and pypi-publish workflow
- Remove Python 3.11 trove classifier from setup.py
- Regenerate pinned requirements with Python 3.12
- Bump version to 4.0.1

Part of the effort to drop Python 3.11 support across OpenEdX repos.
Tracking issue: https://github.com/openedx/public-engineering/issues/499