### PR TITLE
fix: render current config in studio template and prevent auto-save crash

### DIFF
--- a/recommender/__init__.py
+++ b/recommender/__init__.py
@@ -6,4 +6,4 @@ students solving a given problem.
 # which is not loaded when running `manage.py` commands (which is used by `make compile_translations`)
 # from .recommender import RecommenderXBlock
 
-__version__ = '5.0.0'
+__version__ = '5.1.0'

--- a/recommender/recommender.py
+++ b/recommender/recommender.py
@@ -434,10 +434,6 @@ class RecommenderXBlock(HelperXBlock):
         result = self.client_configuration.copy()
         result['is_user_staff'] = self.get_user_is_staff()
         result['intro'] = not self.seen and self.intro_enabled
-        if not self.seen:
-            # Mark the user who interacted with the XBlock first time as seen,
-            # in order not to show the usage tutorial in future.
-            self.seen = True
         tracker.emit('get_client_configuration', result)
         return result
 
@@ -1008,6 +1004,11 @@ class RecommenderXBlock(HelperXBlock):
         frag.add_javascript(self.resource_string("static/js/src/cats.js"))
         frag.add_javascript(self.resource_string("static/js/src/recommender.js"))
         frag.initialize_js('RecommenderXBlock', self.get_client_configuration())
+        # First student view delivered the intro, mark seen so it doesn't
+        # show again. Must happen after get_client_configuration to avoid
+        # writing Scope.user_info during studio_view render (auto-save
+        # rejects user_info).
+        self.seen = True
         return frag
 
     def studio_view(self, _context=None):  # pylint: disable=unused-argument
@@ -1016,8 +1017,14 @@ class RecommenderXBlock(HelperXBlock):
         course staff when editing a course in studio.
         """
         frag = Fragment()
+        configurations = self.get_client_configuration()
         frag.add_content(resource_loader.render_django_template(
-            "templates/recommenderstudio.html",
+            "templates/recommenderstudio.html", {
+                'configurations': configurations,
+                'intro_enabled': self.intro_enabled,
+                'entries_per_page_options': range(1, 11),
+                'page_span_options': range(1, 6),
+            },
             i18n_service=self.runtime.service(self, "i18n")
         ))
         frag.add_css(load("static/css/recommenderstudio.css"))

--- a/recommender/templates/recommenderstudio.html
+++ b/recommender/templates/recommenderstudio.html
@@ -9,39 +9,30 @@
             <div class="recommender_setRecommenderConfigTitle">{% trans "Set the student-view, client side configurations for RecommenderXblock." %}</div>
                 <div class="config">
                     <select name='introEnable' class='introEnable'>
-                        <option value='true'>{% trans "Yes" %}</option>
-                        <option value='false'>{% trans "No" %}</option></select>
+                        <option value='true'{% if intro_enabled %} selected='selected'{% endif %}>{% trans "Yes" %}</option>
+                        <option value='false'{% if not intro_enabled %} selected='selected'{% endif %}>{% trans "No" %}</option></select>
                     <span>{% trans "Do you want to take users on a little tour when they see the RecommenderXBlock first time?" %}</span>
                 </div>
                 <div class="config">
                     <select name='developedUXDisable' class='developedUXDisable'>
-                        <option value='true'>{% trans "Yes" %}</option>
-                        <option value='false'>{% trans "No" %}</option>
+                        <option value='true'{% if configurations.disable_dev_ux %} selected='selected'{% endif %}>{% trans "Yes" %}</option>
+                        <option value='false'{% if not configurations.disable_dev_ux %} selected='selected'{% endif %}>{% trans "No" %}</option>
                     </select>
                     <span>{% trans "Do you want to disable the UX functions which are under development?" %}</span>
                 </div>
                 <div class="config">
                     <select name='entriesPerPage' class='entriesPerPage'>
-                        <option value='1'>1</option>
-                        <option value='2'>2</option>
-                        <option value='3'>3</option>
-                        <option value='4'>4</option>
-                        <option selected='selected' value='5'>5</option>
-                        <option value='6'>6</option>
-                        <option value='7'>7</option>
-                        <option value='8'>8</option>
-                        <option value='9'>9</option>
-                        <option value='10'>10</option>
+                        {% for i in entries_per_page_options %}
+                        <option value='{{ i }}'{% if configurations.entries_per_page == i %} selected='selected'{% endif %}>{{ i }}</option>
+                        {% endfor %}
                     </select>
                     <span>{% trans "How many resources you want to show in each page of the resource list?" %}</span>
                 </div>
                 <div class="config">
                     <select name='pageSpan' class='pageSpan'>
-                        <option value='1'>1</option>
-                        <option selected='selected' value='2'>2</option>
-                        <option value='3'>3</option>
-                        <option value='4'>4</option>
-                        <option value='5'>5</option>
+                        {% for i in page_span_options %}
+                        <option value='{{ i }}'{% if configurations.page_span == i %} selected='selected'{% endif %}>{{ i }}</option>
+                        {% endfor %}
                     </select>
                     <span>{% trans "How many page icons in pagination control (i.e., page range)? The icons for pages from (current page - page range) to (current page + page range) will be shown." %}</span>
                 </div>


### PR DESCRIPTION
**Description**

Pass data from backend to studio editor instead of hardcoded field values. This allows authors to see current configuration values.

Also moves self.seen = True from get_client_configuration to student_view so Studio auto-save (which calls studio_view -> get_client_configuration) does not write Scope.user_info and crash. Pass actual configuration values into the Django template context instead of relying on hardcoded defaults.

**Related**

* https://github.com/openedx/RecommenderXBlock/issues/135
* `Private-ref`: https://tasks.opencraft.com/browse/FAL-3835

**Test instructions**

Follow steps given in #135 and verify that the bug is fixed.
